### PR TITLE
Allowing DocumentId to be specified explicitly.

### DIFF
--- a/src/main/java/com/vidolima/doco/Doco.java
+++ b/src/main/java/com/vidolima/doco/Doco.java
@@ -10,112 +10,115 @@ import com.vidolima.doco.exception.DocumentParseException;
 import com.vidolima.doco.exception.ObjectParseException;
 
 /**
- * This is the main class to use Doco. Doco (Document Converter) is a
- * lightweight Java library used to converts (from and to) indexed Documents
- * provided by Search API in Google App Engine.
+ * This is the main class to use Doco. Doco (Document Converter) is a lightweight Java library used to converts (from
+ * and to) indexed Documents provided by Search API in Google App Engine.
  * 
  * @author Marcos Alexandre Vidolin de Lima
  * @since January 22, 2014
  */
 public final class Doco {
 
-	/**
-	 * Obtains the Index.
-	 * 
-	 * @param clazz
-	 *            the class
-	 * @return the {@link Index} specified with the {@link DocumentIndex}
-	 *         annotation.
-	 */
-	public Index getIndex(Class<?> clazz) {
-		String indexName;
-		try {
-			indexName = ObjectParser.getIndexName(clazz);
-		} catch (AnnotationNotFoundException e) {
-			throw new AnnotationNotFoundException(e.getMessage());
-		}
+    /**
+     * Obtains the Index.
+     * 
+     * @param clazz
+     *            the class
+     * @return the {@link Index} specified with the {@link DocumentIndex} annotation.
+     */
+    public Index getIndex(Class<?> clazz) {
+        String indexName;
+        try {
+            indexName = ObjectParser.getIndexName(clazz);
+        } catch (AnnotationNotFoundException e) {
+            throw new AnnotationNotFoundException(e.getMessage());
+        }
 
-		IndexSpec indexSpec = IndexSpec.newBuilder().setName(indexName).build();
-		Index index = SearchServiceFactory.getSearchService().getIndex(
-				indexSpec);
+        IndexSpec indexSpec = IndexSpec.newBuilder().setName(indexName).build();
+        Index index = SearchServiceFactory.getSearchService().getIndex(indexSpec);
 
-		return index;
-	}
+        return index;
+    }
 
-	/**
-	 * This method converts the specified object, into its equivalent
-	 * {@link Document} representation.
-	 * 
-	 * @param obj
-	 *            the object for which {@link Document} representation is to be
-	 *            created
-	 * @param classOfObj
-	 *            the class of the obj
-	 * @return {@link Document} representation of obj
-	 */
-	public Document toDocument(Object obj, Class<?> classOfObj)
-			throws DocumentParseException {
+    /**
+     * This method converts the specified object, into its equivalent {@link Document} representation.
+     * 
+     * @param obj
+     *            the object for which {@link Document} representation is to be created
+     * @param classOfObj
+     *            the class of the obj
+     * @param documentId
+     *            user defined id of document (e.g. 'Key' of a datastore entity).
+     * @return {@link Document} representation of obj
+     */
+    public Document toDocument(Object obj, String documentId, Class<?> classOfObj) throws DocumentParseException {
 
-		if (obj == null) {
-			return null;
-		}
+        if (obj == null) {
+            return null;
+        }
 
-		Document document = Document.newBuilder().build();
-		DocumentParser parser = new DocumentParser();
+        Document document = Document.newBuilder().build();
+        DocumentParser parser = new DocumentParser();
 
-		try {
-			document = parser.parseDocument(obj, classOfObj);
-		} catch (IllegalArgumentException e) {
-			throw new DocumentParseException("Conversion failed.", e);
-		} catch (IllegalAccessException e) {
-			throw new DocumentParseException("Conversion failed.", e);
-		}
+        try {
+            document = parser.parseDocument(obj, documentId, classOfObj);
+        } catch (IllegalArgumentException e) {
+            throw new DocumentParseException("Conversion failed.", e);
+        } catch (IllegalAccessException e) {
+            throw new DocumentParseException("Conversion failed.", e);
+        }
 
-		return document;
-	}
+        return document;
+    }
 
-	/**
-	 * This method converts the specified object, into its equivalent
-	 * {@link Document} representation.
-	 * 
-	 * @param obj
-	 *            the object for which {@link Document} representation is to be
-	 *            created
-	 * @return {@link Document} representation of obj
-	 */
-	public Document toDocument(Object obj) {
-		return toDocument(obj, obj.getClass());
-	}
+    /**
+     * This method converts the specified object, into its equivalent {@link Document} representation.
+     * 
+     * @param obj
+     *            the object for which {@link Document} representation is to be created
+     * @return {@link Document} representation of obj
+     */
+    public Document toDocument(Object obj) {
+        return toDocument(obj, (String) null);
+    }
 
-	/**
-	 * This method converts the specified {@link Document}, into an object T.
-	 * 
-	 * @param doc
-	 *            the {@link Document} for which object T representation is to
-	 *            be created
-	 * @param classOfT
-	 *            the class of T
-	 * @return T
-	 */
-	public <T> T fromDocument(Document doc, Class<T> classOfT)
-			throws ObjectParseException {
+    /**
+     * This method converts the specified object, into its equivalent {@link Document} representation.
+     * 
+     * @param obj
+     *            the object for which {@link Document} representation is to be created
+     * @param documentId
+     *            user defined id of document (e.g. 'Key' of a datastore entity).
+     * @return {@link Document} representation of obj
+     */
+    public Document toDocument(Object obj, String documentId) {
+        return toDocument(obj, documentId, obj.getClass());
+    }
 
-		if (doc == null) {
-			return null;
-		}
+    /**
+     * This method converts the specified {@link Document}, into an object T.
+     * 
+     * @param doc
+     *            the {@link Document} for which object T representation is to be created
+     * @param classOfT
+     *            the class of T
+     * @return T
+     */
+    public <T> T fromDocument(Document doc, Class<T> classOfT) throws ObjectParseException {
+        if (doc == null) {
+            return null;
+        }
 
-		T instanceOfT = null;
-		ObjectParser parser = new ObjectParser();
+        T instanceOfT = null;
+        ObjectParser parser = new ObjectParser();
 
-		try {
-			instanceOfT = (T) parser.parseObject(doc, classOfT);
-		} catch (InstantiationException e) {
-			throw new ObjectParseException("Conversion failed.", e);
-		} catch (IllegalAccessException e) {
-			throw new ObjectParseException("Conversion failed.", e);
-		}
+        try {
+            instanceOfT = (T) parser.parseObject(doc, classOfT);
+        } catch (InstantiationException e) {
+            throw new ObjectParseException("Conversion failed.", e);
+        } catch (IllegalAccessException e) {
+            throw new ObjectParseException("Conversion failed.", e);
+        }
 
-		return instanceOfT;
-	}
-
+        return instanceOfT;
+    }
 }

--- a/src/main/java/com/vidolima/doco/DocumentParser.java
+++ b/src/main/java/com/vidolima/doco/DocumentParser.java
@@ -194,7 +194,6 @@ final class DocumentParser {
         for (java.lang.reflect.Field f : getAllDocumentField(classOfObj)) {
 
             // TODO: validate field (declaration of annotation)
-
             DocumentField annotation = ObjectParser.getDocumentFieldAnnotation(f);
 
             if (annotation.type().equals(fieldType)) {
@@ -239,16 +238,21 @@ final class DocumentParser {
      * 
      * @param obj
      *            the object to be parsed
+     * @param documentId
+     *            user defined id of document (e.g. 'Key' of a datastore entity).
      * @param typeOfObj
      *            the base class of the given object
      * @return a {@link Document}
      * @throws IllegalAccessException
      * @throws IllegalArgumentException
      */
-    Document parseDocument(Object obj, Class<?> classOfObj) throws IllegalArgumentException, IllegalAccessException {
-
-        java.lang.reflect.Field field = getDocumentIdField(classOfObj);
-        String id = String.valueOf(getId(obj, classOfObj, field.getType()));
+    Document parseDocument(Object obj, String documentId, Class<?> classOfObj) throws IllegalArgumentException,
+        IllegalAccessException {
+        String id = documentId;
+        if (id == null) {
+            java.lang.reflect.Field field = getDocumentIdField(classOfObj);
+            id = String.valueOf(getId(obj, classOfObj, field.getType()));
+        }
 
         Document.Builder builder = Document.newBuilder().setId(id);
 

--- a/src/main/java/com/vidolima/doco/annotation/DocumentField.java
+++ b/src/main/java/com/vidolima/doco/annotation/DocumentField.java
@@ -9,8 +9,7 @@ import java.lang.annotation.Target;
 import com.google.appengine.api.search.Document;
 
 /**
- * Place this annotation on fields of an entity POJO. This annotation defines a field
- * of a {@link Document}.
+ * Place this annotation on fields of an entity POJO. This annotation defines a field of a {@link Document}.
  * 
  * @author Marcos Alexandre Vidolin de Lima
  * @since January 22, 2014
@@ -20,17 +19,17 @@ import com.google.appengine.api.search.Document;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DocumentField {
 
-	/**
-	 * Specifies the name of the field.
-	 * 
-	 * @return name.
-	 */
-	String name() default "";
+    /**
+     * Specifies the name of the field.
+     * 
+     * @return name.
+     */
+    String name() default "";
 
-	/**
-	 * Specifies the {@link FieldType} of the field.
-	 * 
-	 * @return {@link FieldType}.
-	 */
-	FieldType type() default FieldType.TEXT;
+    /**
+     * Specifies the {@link FieldType} of the field.
+     * 
+     * @return {@link FieldType}.
+     */
+    FieldType type() default FieldType.TEXT;
 }

--- a/src/main/java/com/vidolima/doco/annotation/DocumentIndex.java
+++ b/src/main/java/com/vidolima/doco/annotation/DocumentIndex.java
@@ -9,8 +9,7 @@ import java.lang.annotation.Target;
 import com.google.appengine.api.search.IndexSpec;
 
 /**
- * This annotation is applied to the entity class. This annotation defines the
- * name of the {@link IndexSpec}.
+ * This annotation is applied to the entity class. This annotation defines the name of the {@link IndexSpec}.
  * 
  * @author Marcos Alexandre Vidolin de Lima
  * @since February 9, 2014
@@ -20,10 +19,10 @@ import com.google.appengine.api.search.IndexSpec;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DocumentIndex {
 
-	/**
-	 * Specifies the name of the Index.
-	 * 
-	 * @return name.
-	 */
-	String name() default "";
+    /**
+     * Specifies the name of the Index.
+     * 
+     * @return name.
+     */
+    String name() default "";
 }


### PR DESCRIPTION
This is helpful to create Objectify Entity's Key<?> as DocumentId.
