### PR TITLE
@DocumentRef (for Ref<?> fields) and @DocumentEmbed (for embedded fields)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.7</maven.compiler.target>
     <maven.compiler.source>1.7</maven.compiler.source>
+    <objectify.version>5.0</objectify.version>
+    <gae.version>1.9.5</gae.version>
   </properties>
   <licenses>
     <license>
@@ -45,8 +47,31 @@
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>1.9.5</version>
+      <version>${gae.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-labs</artifactId>
+      <version>${gae.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-stubs</artifactId>
+      <version>${gae.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-testing</artifactId>
+      <version>${gae.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Objectify -->
+    <dependency>
+      <groupId>com.googlecode.objectify</groupId>
+      <artifactId>objectify</artifactId>
+      <version>${objectify.version}</version>
     </dependency>
   </dependencies>
   <scm>

--- a/src/main/java/com/vidolima/doco/DocumentParser.java
+++ b/src/main/java/com/vidolima/doco/DocumentParser.java
@@ -4,11 +4,15 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import com.google.appengine.api.datastore.GeoPt;
 import com.google.appengine.api.search.Document;
 import com.google.appengine.api.search.Field;
 import com.google.appengine.api.search.GeoPoint;
+import com.google.common.base.Strings;
+import com.googlecode.objectify.Ref;
 import com.vidolima.doco.annotation.DocumentField;
 import com.vidolima.doco.annotation.DocumentId;
+import com.vidolima.doco.annotation.DocumentRef;
 import com.vidolima.doco.annotation.FieldType;
 import com.vidolima.doco.exception.DocumentParseException;
 
@@ -51,6 +55,10 @@ final class DocumentParser {
      */
     List<java.lang.reflect.Field> getAllDocumentField(Class<?> classOfObj) {
         return ReflectionUtils.getAnnotatedFields(classOfObj, DocumentField.class);
+    }
+
+    private List<java.lang.reflect.Field> getAllRefFields(Class<?> classOfObj) {
+        return ReflectionUtils.getAnnotatedFields(classOfObj, DocumentRef.class);
     }
 
     /**
@@ -159,8 +167,14 @@ final class DocumentParser {
         }
         if (FieldType.GEO_POINT.equals(fieldType)) {
             if (fieldValue != null) {
-                GeoPoint geoPoint = (GeoPoint) fieldValue;
-                return Field.newBuilder().setName(name).setGeoPoint(geoPoint).build();
+                if (fieldValue instanceof GeoPt) {
+                    GeoPt geoPt = (GeoPt) fieldValue;
+                    GeoPoint geoPoint = new GeoPoint(geoPt.getLatitude(), geoPt.getLongitude());
+                    return Field.newBuilder().setName(name).setGeoPoint(geoPoint).build();
+                } else {
+                    GeoPoint geoPoint = (GeoPoint) fieldValue;
+                    return Field.newBuilder().setName(name).setGeoPoint(geoPoint).build();
+                }
             }
         }
         if (FieldType.NUMBER.equals(fieldType))
@@ -186,8 +200,8 @@ final class DocumentParser {
      * @throws IllegalArgumentException
      * @throws IllegalAccessException
      */
-    List<com.google.appengine.api.search.Field> getAllSearchFieldsByType(Object obj, Class<?> classOfObj,
-        FieldType fieldType) throws IllegalArgumentException, IllegalAccessException {
+    List<com.google.appengine.api.search.Field> getAllSearchFieldsByType(String fieldNamePrefix, Object obj,
+        Class<?> classOfObj, FieldType fieldType) throws IllegalArgumentException, IllegalAccessException {
 
         List<com.google.appengine.api.search.Field> fields = new ArrayList<Field>(0);
 
@@ -198,7 +212,8 @@ final class DocumentParser {
 
             if (annotation.type().equals(fieldType)) {
                 String name = ObjectParser.getFieldNameValue(f, annotation);
-                com.google.appengine.api.search.Field field = getSearchFieldByFieldType(name, f, obj, fieldType);
+                String fullName = Strings.isNullOrEmpty(fieldNamePrefix) ? name : fieldNamePrefix + "_" + name;
+                com.google.appengine.api.search.Field field = getSearchFieldByFieldType(fullName, f, obj, fieldType);
                 if (field != null) {
                     fields.add(field);
                 }
@@ -219,13 +234,14 @@ final class DocumentParser {
      * @throws IllegalArgumentException
      * @throws IllegalAccessException
      */
-    List<com.google.appengine.api.search.Field> getAllSearchFields(Object obj, Class<?> classOfObj)
-        throws IllegalArgumentException, IllegalAccessException {
+    List<com.google.appengine.api.search.Field> getAllSearchFields(String fieldNamePrefix, Object obj,
+        Class<?> classOfObj) throws IllegalArgumentException, IllegalAccessException {
 
         List<com.google.appengine.api.search.Field> fields = new ArrayList<com.google.appengine.api.search.Field>();
 
         for (FieldType type : FieldType.values()) {
-            for (com.google.appengine.api.search.Field f : getAllSearchFieldsByType(obj, classOfObj, type)) {
+            for (com.google.appengine.api.search.Field f : getAllSearchFieldsByType(fieldNamePrefix, obj, classOfObj,
+                type)) {
                 fields.add(f);
             }
         }
@@ -256,11 +272,65 @@ final class DocumentParser {
 
         Document.Builder builder = Document.newBuilder().setId(id);
 
-        for (com.google.appengine.api.search.Field f : getAllSearchFields(obj, classOfObj)) {
+        for (com.google.appengine.api.search.Field f : getAllFieldsForDocument("", obj, classOfObj)) {
             if (f != null) {
                 builder.addField(f);
             }
         }
+
         return builder.build();
+    }
+
+    /**
+     * Parses class for presence of @DocumentField, @DocumentRef, etc. annotations and generates {@link Field} from it.
+     * 
+     * @param fieldNamePrefix
+     *            prefix for field names if any. Normally this should be set to empty string or null. When supplied,
+     *            name of field becomes <b>prefix_</b>fieldName
+     * @param obj
+     *            object whcih should be used to get value of document fields.
+     * @param classOfObj
+     *            class of 'obj' parameter
+     * @return All possible fields which are to be added to the search document including fields of Ref entity.
+     */
+    private List<com.google.appengine.api.search.Field> getAllFieldsForDocument(String fieldNamePrefix, Object obj,
+        Class<?> classOfObj) throws IllegalArgumentException, IllegalAccessException {
+        List<com.google.appengine.api.search.Field> eligibleFields = new ArrayList<>();
+        // get fields annotated with @DocumentField
+        for (com.google.appengine.api.search.Field f : getAllSearchFields(fieldNamePrefix, obj, classOfObj)) {
+            if (f != null) {
+                eligibleFields.add(f);
+            }
+        }
+        // get fields annotated with @DocumentRef
+        for (com.google.appengine.api.search.Field f : getAllSearchFieldsFromRefClass(fieldNamePrefix, obj, classOfObj)) {
+            if (f != null) {
+                eligibleFields.add(f);
+            }
+        }
+        return eligibleFields;
+    }
+
+    /**
+     * Creates {@link Field} for all annotated fields in the class of field annotated with {@link DocumentRef}
+     */
+    private List<com.google.appengine.api.search.Field> getAllSearchFieldsFromRefClass(String fieldNamePrefix,
+        Object obj, Class<?> classOfObj) throws IllegalArgumentException, IllegalAccessException {
+        List<com.google.appengine.api.search.Field> searchFields = new ArrayList<com.google.appengine.api.search.Field>();
+        List<java.lang.reflect.Field> declaredFields = getAllRefFields(classOfObj);
+        for (java.lang.reflect.Field declaredField : declaredFields) {
+            Object fieldValue = declaredField.get(obj);
+            // get the class from the annotation on this field (guaranteed to be annotated since we specifically asked
+            // for annotated fields only)
+            Class<?> refClass = declaredField.getAnnotation(DocumentRef.class).type();
+            if (!(fieldValue instanceof Ref<?>)) {
+                throw new IllegalStateException("Incorrect mapping found on field: " + declaredField.getName());
+            }
+            Ref<?> ref = (Ref<?>) fieldValue;
+            String newFieldNamePrefix = Strings.isNullOrEmpty(fieldNamePrefix) ? refClass.getSimpleName()
+                : fieldNamePrefix + "_" + refClass.getSimpleName();
+            searchFields.addAll(getAllFieldsForDocument(newFieldNamePrefix, ref.get(), refClass));
+        }
+        return searchFields;
     }
 }

--- a/src/main/java/com/vidolima/doco/DocumentParser.java
+++ b/src/main/java/com/vidolima/doco/DocumentParser.java
@@ -328,9 +328,11 @@ final class DocumentParser {
         List<java.lang.reflect.Field> declaredFields = getAllEmbedFields(classOfObj);
         for (java.lang.reflect.Field declaredField : declaredFields) {
             Object fieldValue = declaredField.get(obj);
-            String newFieldNamePrefix = Strings.isNullOrEmpty(fieldNamePrefix) ? fieldValue.getClass().getSimpleName()
-                : (fieldNamePrefix + "_" + fieldValue.getClass().getSimpleName());
-            searchFields.addAll(getAllFieldsForDocument(newFieldNamePrefix, fieldValue, fieldValue.getClass()));
+            if (fieldValue != null) {
+                String newFieldNamePrefix = Strings.isNullOrEmpty(fieldNamePrefix) ? declaredField.getType()
+                    .getSimpleName() : (fieldNamePrefix + "_" + declaredField.getType().getSimpleName());
+                searchFields.addAll(getAllFieldsForDocument(newFieldNamePrefix, fieldValue, declaredField.getType()));
+            }
         }
         return searchFields;
     }

--- a/src/main/java/com/vidolima/doco/annotation/DocumentEmbed.java
+++ b/src/main/java/com/vidolima/doco/annotation/DocumentEmbed.java
@@ -7,7 +7,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Some doc.
+ * Use this annotation on embedded fields.
  */
 @Documented
 @Target(ElementType.FIELD)

--- a/src/main/java/com/vidolima/doco/annotation/DocumentEmbed.java
+++ b/src/main/java/com/vidolima/doco/annotation/DocumentEmbed.java
@@ -1,0 +1,17 @@
+package com.vidolima.doco.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Some doc.
+ */
+@Documented
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DocumentEmbed {
+    String name() default "";
+}

--- a/src/main/java/com/vidolima/doco/annotation/DocumentRef.java
+++ b/src/main/java/com/vidolima/doco/annotation/DocumentRef.java
@@ -1,0 +1,36 @@
+package com.vidolima.doco.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.google.appengine.api.search.Document;
+
+/**
+ * Place this annotation on fields of type Ref<?> from objectify. This annotation adds all the annotated fields of the
+ * specified class to the same {@link Document} as other fields of this class.
+ * 
+ * Fields from referenced class follow following naming scheme:
+ * 
+ * <pre>
+ * Class A {
+ *   @DocumentRef(type = B.class)
+ *   Ref<B> refB;
+ * }
+ * 
+ * Class B {
+ *   @DocumentField(type = TEXT)
+ *   String text;
+ * }
+ * </pre>
+ * 
+ * For above classes, if document is generated for class A, it'll have B's fields prefixed with "B_" (i.e. B_text).
+ */
+@Documented
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DocumentRef {
+    Class<?> type();
+}

--- a/src/test/java/com/vidolima/doco/DocumentEmbedTest.java
+++ b/src/test/java/com/vidolima/doco/DocumentEmbedTest.java
@@ -41,6 +41,7 @@ public class DocumentEmbedTest {
             this.text = text;
             this.bRef = bRef;
             this.number = number;
+            this.bNull = null; // intentional null to make sure doco works fine with nulls
         }
 
         @DocumentId
@@ -50,6 +51,8 @@ public class DocumentEmbedTest {
         long number;
         @DocumentEmbed
         B bRef;
+        @DocumentEmbed
+        B bNull;
     }
 
     @Entity

--- a/src/test/java/com/vidolima/doco/DocumentEmbedTest.java
+++ b/src/test/java/com/vidolima/doco/DocumentEmbedTest.java
@@ -1,60 +1,35 @@
 package com.vidolima.doco;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import com.google.appengine.api.datastore.GeoPt;
 import com.google.appengine.api.search.Document;
-import com.googlecode.objectify.Key;
-import com.googlecode.objectify.ObjectifyService;
-import com.googlecode.objectify.Ref;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
+import com.vidolima.doco.annotation.DocumentEmbed;
 import com.vidolima.doco.annotation.DocumentField;
 import com.vidolima.doco.annotation.DocumentId;
-import com.vidolima.doco.annotation.DocumentRef;
 import com.vidolima.doco.annotation.FieldType;
-import com.vidolima.doco.utils.AppEngineTestUtils;
 
-public class DocumentRefTest {
-
-    private AppEngineTestUtils testUtils = new AppEngineTestUtils();
-
-    static {
-        ObjectifyService.register(B.class);
-        ObjectifyService.register(C.class);
-    }
-
-    @Before
-    public void setupTests() {
-        testUtils.setUp();
-    }
-
-    @After
-    public void teardownTests() {
-        testUtils.tearDown();
-    }
+public class DocumentEmbedTest {
 
     @Test
     public void testRefFieldConversionSuccess() {
         final String cId = "id of class C";
         C c = new C(cId);
-        Key<C> cKey = ObjectifyService.ofy().save().entity(c).now();
         final long b_numberVal = 10L;
-        B b = new B(b_numberVal, Ref.create(cKey));
-        Key<B> bKey = ObjectifyService.ofy().save().entity(b).now();
+        B b = new B(b_numberVal, c);
         final String textVal = "myText";
         final long a_numberVal = 20L;
-        A a = new A(textVal, a_numberVal, Ref.create(bKey));
+        A a = new A(textVal, a_numberVal, b);
 
         Doco doco = new Doco();
         // now save 'a' which contains ref for object 'b'
         Document document = doco.toDocument(a);
         System.out.println(document.toString());
-        // resulting document should have fields of both 'a', 'b' and 'c'
+        // resulting document should have fields of all 'a', 'b' and 'c'
         assertEquals(textVal, document.getOnlyField("text").getText());
         assertEquals(a_numberVal, document.getOnlyField("number").getNumber().longValue());
         assertEquals(b_numberVal, document.getOnlyField("B_number").getNumber().longValue());
@@ -62,7 +37,7 @@ public class DocumentRefTest {
     }
 
     static class A {
-        public A(String text, long number, Ref<B> bRef) {
+        public A(String text, long number, B bRef) {
             this.text = text;
             this.bRef = bRef;
             this.number = number;
@@ -73,8 +48,8 @@ public class DocumentRefTest {
         String text;
         @DocumentField(type = FieldType.NUMBER)
         long number;
-        @DocumentRef(type = B.class)
-        Ref<B> bRef;
+        @DocumentEmbed
+        B bRef;
     }
 
     @Entity
@@ -84,10 +59,10 @@ public class DocumentRefTest {
         long number;
         @DocumentField(type = FieldType.GEO_POINT)
         GeoPt geoPt;
-        @DocumentRef(type = C.class)
-        Ref<C> cRef;
+        @DocumentEmbed
+        C cRef;
 
-        public B(long num, Ref<C> cRef) {
+        public B(long num, C cRef) {
             this.number = num;
             this.cRef = cRef;
             this.geoPt = new GeoPt(10.23f, 45.67f);

--- a/src/test/java/com/vidolima/doco/DocumentRefTest.java
+++ b/src/test/java/com/vidolima/doco/DocumentRefTest.java
@@ -1,0 +1,102 @@
+package com.vidolima.doco;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.appengine.api.search.Document;
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.ObjectifyService;
+import com.googlecode.objectify.Ref;
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+import com.vidolima.doco.annotation.DocumentField;
+import com.vidolima.doco.annotation.DocumentId;
+import com.vidolima.doco.annotation.DocumentRef;
+import com.vidolima.doco.annotation.FieldType;
+import com.vidolima.doco.utils.AppEngineTestUtils;
+
+public class DocumentRefTest {
+
+    private AppEngineTestUtils testUtils = new AppEngineTestUtils();
+
+    static {
+        ObjectifyService.register(B.class);
+        ObjectifyService.register(C.class);
+    }
+
+    @Before
+    public void setupTests() {
+        testUtils.setUp();
+    }
+
+    @After
+    public void teardownTests() {
+        testUtils.tearDown();
+    }
+
+    @Test
+    public void testRefFieldConversionSuccess() {
+        final String cId = "id of class C";
+        C c = new C(cId);
+        Key<C> cKey = ObjectifyService.ofy().save().entity(c).now();
+        final long b_numberVal = 10L;
+        B b = new B(b_numberVal, Ref.create(cKey));
+        Key<B> bKey = ObjectifyService.ofy().save().entity(b).now();
+        final String textVal = "myText";
+        final long a_numberVal = 20L;
+        A a = new A(textVal, a_numberVal, Ref.create(bKey));
+
+        Doco doco = new Doco();
+        // now save 'a' which contains ref for object 'b'
+        Document document = doco.toDocument(a);
+        // resulting document should have fields of both 'a', 'b' and 'c'
+        assertEquals(textVal, document.getOnlyField("text").getText());
+        assertEquals(a_numberVal, document.getOnlyField("number").getNumber().longValue());
+        assertEquals(b_numberVal, document.getOnlyField("B_number").getNumber().longValue());
+        assertEquals(cId, document.getOnlyField("B_C_cId").getText());
+    }
+
+    static class A {
+        public A(String text, long number, Ref<B> bRef) {
+            this.text = text;
+            this.bRef = bRef;
+            this.number = number;
+        }
+
+        @DocumentId
+        @DocumentField(type = FieldType.TEXT)
+        String text;
+        @DocumentField(type = FieldType.NUMBER)
+        long number;
+        @DocumentRef(type = B.class)
+        Ref<B> bRef;
+    }
+
+    @Entity
+    static class B {
+        @DocumentField(type = FieldType.NUMBER)
+        @Id
+        long number;
+        @DocumentRef(type = C.class)
+        Ref<C> cRef;
+
+        public B(long num, Ref<C> cRef) {
+            this.number = num;
+            this.cRef = cRef;
+        }
+    }
+
+    @Entity
+    static class C {
+        @DocumentField(type = FieldType.TEXT)
+        @Id
+        String cId;
+
+        public C(String id) {
+            this.cId = id;
+        }
+    }
+}

--- a/src/test/java/com/vidolima/doco/utils/AppEngineTestUtils.java
+++ b/src/test/java/com/vidolima/doco/utils/AppEngineTestUtils.java
@@ -1,0 +1,29 @@
+package com.vidolima.doco.utils;
+
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+
+/**
+ * Needed to test classes with annotations specific to app-engine.
+ */
+public class AppEngineTestUtils {
+    /**
+     * This utility is provided by AppEngine to run tests locally. {@link LocalDatastoreServiceTestConfig} has multiple
+     * methods to simulate actual environment.
+     * 
+     * Initialize data store as HRD by specifying 100% High Rep job policy.
+     */
+    private final LocalServiceTestHelper datastoreServiceTestHelper;
+
+    public AppEngineTestUtils() {
+        datastoreServiceTestHelper = new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+    }
+
+    public void setUp() {
+        datastoreServiceTestHelper.setUp();
+    }
+
+    public void tearDown() {
+        datastoreServiceTestHelper.tearDown();
+    }
+}


### PR DESCRIPTION
Introducing dependency on Objectify.
* Doco can now translate Ref<?> fields using @DocumentRef annotation.
  * All the fields of Ref<?> class are prefixed with simple name of Ref<?> type.
  * Added tests for same which shows that arbitrary nesting is possible.
  * There is a possibility of creating circular references in which processing @DocumentRef will run into infinite recursion.

* Supporting embedded fields using @DocumentEmbed annotation.
  * This is useful when an entity contains other classes which has fields needing indexing.