### PR TITLE
Adding limit support for Facets.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.7</maven.compiler.target>
     <maven.compiler.source>1.7</maven.compiler.source>
-    <objectify.version>5.1</objectify.version>
+    <objectify.version>5.0</objectify.version>
     <gae.version>1.9.22</gae.version>
   </properties>
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.7</maven.compiler.target>
     <maven.compiler.source>1.7</maven.compiler.source>
-    <objectify.version>5.0</objectify.version>
-    <gae.version>1.9.5</gae.version>
+    <objectify.version>5.1</objectify.version>
+    <gae.version>1.9.22</gae.version>
   </properties>
   <licenses>
     <license>
@@ -72,6 +72,11 @@
       <groupId>com.googlecode.objectify</groupId>
       <artifactId>objectify</artifactId>
       <version>${objectify.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.4</version>
     </dependency>
   </dependencies>
   <scm>

--- a/src/main/java/com/vidolima/doco/DocumentParser.java
+++ b/src/main/java/com/vidolima/doco/DocumentParser.java
@@ -317,7 +317,7 @@ final class DocumentParser {
         String facetName = StringUtils.isNotBlank(annotation.name()) ? annotation.name() : f.getName();
         switch (annotation.type()) {
         case ATOM:
-            return Facet.withAtom(facetName, (String) f.get(obj));
+            return Facet.withAtom(facetName, String.valueOf(f.get(obj)));
         case NUMBER:
             return Facet.withNumber(facetName, Double.valueOf(String.valueOf(f.get(obj))));
         default:

--- a/src/main/java/com/vidolima/doco/DocumentParser.java
+++ b/src/main/java/com/vidolima/doco/DocumentParser.java
@@ -4,8 +4,11 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.google.appengine.api.datastore.GeoPt;
 import com.google.appengine.api.search.Document;
+import com.google.appengine.api.search.Facet;
 import com.google.appengine.api.search.Field;
 import com.google.appengine.api.search.GeoPoint;
 import com.google.common.base.Strings;
@@ -14,6 +17,7 @@ import com.vidolima.doco.annotation.DocumentEmbed;
 import com.vidolima.doco.annotation.DocumentField;
 import com.vidolima.doco.annotation.DocumentId;
 import com.vidolima.doco.annotation.DocumentRef;
+import com.vidolima.doco.annotation.FacetField;
 import com.vidolima.doco.annotation.FieldType;
 import com.vidolima.doco.exception.DocumentParseException;
 
@@ -24,6 +28,8 @@ import com.vidolima.doco.exception.DocumentParseException;
  * @since January 28, 2014
  */
 final class DocumentParser {
+
+    private static final String DEFAULT_FIELD_NAME_PREFIX = "";
 
     /**
      * Obtains the {@link java.lang.reflect.Field} annotated with {@link DocumentId} annotation.
@@ -64,6 +70,10 @@ final class DocumentParser {
 
     private List<java.lang.reflect.Field> getAllEmbedFields(Class<?> classOfObj) {
         return ReflectionUtils.getAnnotatedFields(classOfObj, DocumentEmbed.class);
+    }
+
+    List<java.lang.reflect.Field> getAllFacetFields(Class<?> classOfObj) {
+        return ReflectionUtils.getAnnotatedFields(classOfObj, FacetField.class);
     }
 
     /**
@@ -277,13 +287,42 @@ final class DocumentParser {
 
         Document.Builder builder = Document.newBuilder().setId(id);
 
-        for (com.google.appengine.api.search.Field f : getAllFieldsForDocument("", obj, classOfObj)) {
+        for (com.google.appengine.api.search.Field f : getAllFieldsForDocument(DEFAULT_FIELD_NAME_PREFIX, obj,
+            classOfObj)) {
             if (f != null) {
                 builder.addField(f);
             }
         }
 
+        for (Facet facet : getAllFacetsForDocument(obj, classOfObj)) {
+            builder.addFacet(facet);
+        }
+
         return builder.build();
+    }
+
+    private List<Facet> getAllFacetsForDocument(Object obj, Class<?> classOfObj) throws IllegalArgumentException,
+        IllegalAccessException {
+        List<Facet> facetsInClass = new ArrayList<>();
+        for (java.lang.reflect.Field f : getAllFacetFields(classOfObj)) {
+            Facet facet = getFacetValueFromField(f, obj);
+            facetsInClass.add(facet);
+        }
+        return facetsInClass;
+    }
+
+    private Facet getFacetValueFromField(java.lang.reflect.Field f, Object obj) throws IllegalArgumentException,
+        IllegalAccessException {
+        FacetField annotation = f.getAnnotation(FacetField.class);
+        String facetName = StringUtils.isNotBlank(annotation.name()) ? annotation.name() : f.getName();
+        switch (annotation.type()) {
+        case ATOM:
+            return Facet.withAtom(facetName, (String) f.get(obj));
+        case NUMBER:
+            return Facet.withNumber(facetName, Double.valueOf(String.valueOf(f.get(obj))));
+        default:
+            throw new IllegalStateException(String.format("Unknown facet type %s found", facetName));
+        }
     }
 
     /**

--- a/src/main/java/com/vidolima/doco/annotation/FacetField.java
+++ b/src/main/java/com/vidolima/doco/annotation/FacetField.java
@@ -1,0 +1,31 @@
+package com.vidolima.doco.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Place this annotation on fields of an entity POJO which should be used as Facets. Find out more about facets at <a
+ * href="https://cloud.google.com/appengine/docs/java/search/faceted_search#adding_facets_to_a_document">here</a>.
+ */
+@Documented
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FacetField {
+
+    /**
+     * Specifies the name of the field.
+     * 
+     * @return name.
+     */
+    String name() default "";
+
+    /**
+     * Specifies the {@link FieldType} of the field.
+     * 
+     * @return {@link FieldType}.
+     */
+    FacetType type();
+}

--- a/src/main/java/com/vidolima/doco/annotation/FacetType.java
+++ b/src/main/java/com/vidolima/doco/annotation/FacetType.java
@@ -1,0 +1,12 @@
+package com.vidolima.doco.annotation;
+
+/**
+ * Defines all valid facet types. Place one of these type in a {@link FacetField} annotation.
+ * 
+ * All possible facet types are defined at <a
+ * href="https://cloud.google.com/appengine/docs/java/javadoc/com/google/appengine/api/search/Facet">here</a>.
+ */
+public enum FacetType {
+    ATOM,
+    NUMBER
+}

--- a/src/test/java/com/vidolima/doco/FacetTest.java
+++ b/src/test/java/com/vidolima/doco/FacetTest.java
@@ -1,0 +1,61 @@
+package com.vidolima.doco;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.google.appengine.api.search.Document;
+import com.google.appengine.api.search.Facet;
+import com.vidolima.doco.annotation.DocumentField;
+import com.vidolima.doco.annotation.DocumentId;
+import com.vidolima.doco.annotation.DocumentIndex;
+import com.vidolima.doco.annotation.FacetField;
+import com.vidolima.doco.annotation.FacetType;
+import com.vidolima.doco.annotation.FieldType;
+
+public class FacetTest {
+
+    @DocumentIndex
+    class Foo {
+        static final String STRING_FIELD_NAME = "stringField";
+        static final String FACET_NAME = "differentName";
+        static final String DOUBLE_FIELD_NAME = "doubleField";
+
+        public Foo(String stringField, long numberField, double doubleField) {
+            this.stringField = stringField;
+            this.fieldWithFacetName = numberField;
+            this.doubleField = doubleField;
+        }
+
+        @DocumentId
+        @FacetField(type = FacetType.ATOM)
+        String stringField;
+
+        @DocumentField(type = FieldType.NUMBER)
+        @FacetField(type = FacetType.NUMBER, name = FACET_NAME)
+        long fieldWithFacetName;
+
+        @FacetField(type = FacetType.NUMBER)
+        double doubleField;
+    }
+
+    @Test
+    public void testFacetGenerationSuccess() {
+        Doco doco = new Doco();
+        // now save 'a' which contains ref for object 'b'
+        Document document = doco.toDocument(new Foo("blah", 1L, 2.0));
+
+        // verification
+        Facet stringFieldFacet = document.getOnlyFacet(Foo.STRING_FIELD_NAME);
+        assertEquals(Foo.STRING_FIELD_NAME, stringFieldFacet.getName());
+        assertEquals("blah", stringFieldFacet.getAtom());
+
+        Facet longFieldFacet = document.getOnlyFacet(Foo.FACET_NAME);
+        assertEquals(Foo.FACET_NAME, longFieldFacet.getName());
+        assertEquals(1, longFieldFacet.getNumber().longValue());
+
+        Facet doubleFieldFacet = document.getOnlyFacet(Foo.DOUBLE_FIELD_NAME);
+        assertEquals(Foo.DOUBLE_FIELD_NAME, doubleFieldFacet.getName());
+        assertEquals(2.0, doubleFieldFacet.getNumber().doubleValue(), 0.001);
+    }
+}


### PR DESCRIPTION
Limited because it only works on the main class and does not work on following:

1. Subclass
* Embedded Classes
* Ref entities.
We've supported DocumentField annotation for all such cases in past and we'll do it for Facets in future as well.

Also, updated app-engine version.