### PR TITLE
Fixed Double counting issue for ID, plus convenience for adding index name to subclass

### DIFF
--- a/src/main/java/com/vidolima/doco/ObjectParser.java
+++ b/src/main/java/com/vidolima/doco/ObjectParser.java
@@ -36,7 +36,9 @@ final class ObjectParser {
                         + " class.");
             }
 
-            return clazz.getSimpleName();
+            String name = indexSubClass.name();
+
+            return (name != null && name.length() > 0)? name : clazz.getSimpleName();
         }
         else {
             String name = annotation.name();

--- a/src/main/java/com/vidolima/doco/ReflectionUtils.java
+++ b/src/main/java/com/vidolima/doco/ReflectionUtils.java
@@ -40,9 +40,8 @@ final class ReflectionUtils {
             }
         }
         // search in super class as well if annotations tells us.
-        while (classOfObj.getAnnotation(DocumentIndexSubClass.class) != null) {
+        if (classOfObj.getAnnotation(DocumentIndexSubClass.class) != null) {
             result.addAll(getAnnotatedFields(classOfObj.getSuperclass(), classOfAnnotation));
-            classOfObj = classOfObj.getSuperclass(); // very imp, otherwise infinite recursion
         }
 
         return result;

--- a/src/main/java/com/vidolima/doco/annotation/DocumentIndexSubClass.java
+++ b/src/main/java/com/vidolima/doco/annotation/DocumentIndexSubClass.java
@@ -13,4 +13,10 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DocumentIndexSubClass {
+	/**
+     * Specifies the name of the Index.
+     * 
+     * @return name.
+     */
+    String name() default "";
 }


### PR DESCRIPTION
ReflectionUtil getAnnotatedFields() method has an over counting issue.

sub-sub-class -> sub-class -> parent class (@DocoIndex)

your while loop counts the two ids.